### PR TITLE
Change email service to Brevo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,8 @@ gem "matrix", "~> 0.4.3"
 # HTTP Accept-Language header filtering library
 gem "http_accept_language", "~> 2.1"
 
+gem 'brevo-rails'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,8 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     base64 (0.3.0)
     bcrypt (3.1.20)
     bigdecimal (3.2.2)
@@ -68,6 +70,13 @@ GEM
       msgpack (~> 1.2)
     brakeman (7.0.2)
       racc
+    brevo (2.0.0)
+      addressable (~> 2.3, >= 2.3.0)
+      json (~> 2.1, >= 2.1.0)
+      typhoeus (~> 1.0, >= 1.0.1)
+    brevo-rails (1.1.1)
+      activesupport (> 4.3)
+      brevo (~> 2.0)
     builder (3.3.0)
     bundle-audit (0.1.0)
       bundler-audit
@@ -91,6 +100,8 @@ GEM
     erubi (1.13.1)
     et-orbi (1.2.11)
       tzinfo
+    ethon (0.16.0)
+      ffi (>= 1.15.0)
     execjs (2.10.0)
     factory_bot (6.5.4)
       activesupport (>= 6.1.0)
@@ -112,6 +123,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    json (2.12.2)
     kt-paperclip (7.2.2)
       activemodel (>= 4.2.0)
       activesupport (>= 4.2.0)
@@ -159,6 +171,7 @@ GEM
     prawn (2.4.0)
       pdf-core (~> 0.9.0)
       ttfunk (~> 1.7)
+    public_suffix (6.0.2)
     puma (5.6.9)
       nio4r (~> 2.0)
     puma-daemon (0.5.0)
@@ -266,6 +279,8 @@ GEM
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
+    typhoeus (1.4.1)
+      ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uglifier (4.2.1)
@@ -290,6 +305,7 @@ DEPENDENCIES
   bcrypt (~> 3.1.15)
   bootsnap (>= 1.4.4)
   brakeman
+  brevo-rails
   bundle-audit
   byebug
   coffee-rails (~> 4.2)

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'noreply@mail.falaeapp.org'
+  default from: 'Falae App <voluntarios.educandario@gmail.com>'
   layout 'mailer'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,17 +71,10 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp
-  host = 'falaeapp.org'
-  config.action_mailer.default_url_options = { host: host }
-  ActionMailer::Base.smtp_settings = {
-    :address        => 'smtp.sendgrid.net',
-    :port           => '465',
-    :authentication => :plain,
-    :user_name      => 'apikey',
-    :password       => ENV['SENDGRID_APIKEY'],
-    :domain         => host,
-    :enable_starttls_auto => true,
-    :ssl            => true
+  config.action_mailer.default_url_options = { host: 'falaeapp.org' }
+  config.action_mailer.delivery_method = :brevo
+  config.action_mailer.brevo_settings = {
+    api_key: ENV.fetch('BREVO_API_KEY'),
   }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to


### PR DESCRIPTION
Previous email service, Sendgrid, has changed its free-tier to a 60 days free trial. So switch to Brevo which has a free tier.